### PR TITLE
fix: (attempt) setup pnpm in action and cache deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,24 +12,44 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Repo
+      - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
+      - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
-      - name: Install Dependencies
-        run: pnpm
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
         # uncomment lines below when ready to publish
         # with:
-          # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          # publish: yarn release
+        # This expects you to have a script called release which does a build for your packages and calls changeset publish
+        # publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # Uncomment below when ready to publish


### PR DESCRIPTION
## Description

BUG: PNPM isn't installed when running workflows

FIX: Use [pnpm/action-setup](https://github.com/pnpm/action-setup) to install before running workflows. 

This fix uses the pnpm store to handle caching as well.

----

## Changed

## Added

## Deleted
